### PR TITLE
API change needed to fix switch chunkload errors

### DIFF
--- a/mods/railcraft/api/tracks/ISwitchDevice.java
+++ b/mods/railcraft/api/tracks/ISwitchDevice.java
@@ -17,4 +17,6 @@ public interface ISwitchDevice {
      */
     public boolean shouldSwitch(ITrackSwitch switchTrack, EntityMinecart cart);
 
+    public boolean isInvalid();
+
 }

--- a/mods/railcraft/api/tracks/ITrackSwitch.java
+++ b/mods/railcraft/api/tracks/ITrackSwitch.java
@@ -8,9 +8,9 @@ public interface ITrackSwitch extends ITrackInstance {
     public boolean isSwitched();
 
     /**
-     * @see #registerSwitch(ISwitchDevice)
+     * @see #getSwitchDevice()
      * @see mods.railcraft.api.tracks.ISwitchDevice
-     * @deprecated replaced by registerSwitch() and ISwitchDevice
+     * @deprecated replaced by getSwitchDevice()
      */
     @Deprecated
     public void setSwitched(boolean switched);
@@ -26,4 +26,8 @@ public interface ITrackSwitch extends ITrackInstance {
      * @return the ISwitchDevice that can interact with this switch track
      */
     public ISwitchDevice getSwitchDevice();
+
+    enum ArrowDirection {
+        NORTH, SOUTH, EAST, WEST, NORTH_SOUTH, EAST_WEST
+    }
 }

--- a/mods/railcraft/api/tracks/ITrackSwitch.java
+++ b/mods/railcraft/api/tracks/ITrackSwitch.java
@@ -1,19 +1,8 @@
 package mods.railcraft.api.tracks;
 
-
-import net.minecraft.util.AxisAlignedBB;
-
 public interface ITrackSwitch extends ITrackInstance {
 
     public boolean isSwitched();
-
-    /**
-     * @see #getSwitchDevice()
-     * @see mods.railcraft.api.tracks.ISwitchDevice
-     * @deprecated replaced by getSwitchDevice()
-     */
-    @Deprecated
-    public void setSwitched(boolean switched);
 
     public boolean isMirrored();
 

--- a/mods/railcraft/api/tracks/ITrackSwitch.java
+++ b/mods/railcraft/api/tracks/ITrackSwitch.java
@@ -22,24 +22,8 @@ public interface ITrackSwitch extends ITrackInstance {
     public ArrowDirection getWhiteSignDirection();
 
     /**
-     * @return null
-     * @see #registerSwitch(ISwitchDevice)
-     * @see mods.railcraft.api.tracks.ISwitchDevice
-     * @deprecated replaced by registerSwitch() and ISwitchDevice
+     * This method should only return a valid (isInvalid() == false) ISwitchDevice or null
+     * @return the ISwitchDevice that can interact with this switch track
      */
-    @Deprecated
-    public AxisAlignedBB getRoutingSearchBox();
-
-    /**
-     * Register a controller device to the switch.
-     * This device will provide guidance to switch
-     * as to which direction a cart should travel.
-     *
-     * @param switchDevice
-     */
-    public void registerSwitch(ISwitchDevice switchDevice);
-
-    enum ArrowDirection {
-        NORTH, SOUTH, EAST, WEST, NORTH_SOUTH, EAST_WEST
-    }
+    public ISwitchDevice getSwitchDevice();
 }


### PR DESCRIPTION
Added getSwitchDevice() method
Removed deprecated methods and registerSwitch as they are not needed and should not be implemented in implementing classes.