### PR TITLE
No longer do a linear search through a HashMap

### DIFF
--- a/mods/railcraft/api/fuel/FuelManager.java
+++ b/mods/railcraft/api/fuel/FuelManager.java
@@ -13,7 +13,6 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import net.minecraftforge.fluids.Fluid;
 import org.apache.logging.log4j.Level;
 
@@ -43,11 +42,9 @@ public class FuelManager {
     }
 
     public static int getBoilerFuelValue(Fluid fluid) {
-        for (Entry<Fluid, Integer> entry : boilerFuel.entrySet()) {
-            if (entry.getKey() == fluid)
-                return entry.getValue();
-        }
-        return 0;
+        Integer value = boilerFuel.get(fluid);
+        if(value != null) return value.intValue();
+        else return 0;
     }
 
 }


### PR DESCRIPTION
The old `FuelManager` code goes to all the trouble of setting up a `HashMap` to store its values in, but then does a linear search when it comes time to retrieve a value. This patch changes that, reaping the full benefit of a `HashMap`. The externally-visible behavior and fields are identical, and in particular, this code will do the Right Thing when presented with a null `Fluid`, or a `Fluid` that is not registered. (The old code also did the Right Thing; this is merely a performance enhancement.)