### PR TITLE
Minecraft 1.11

### DIFF
--- a/mods/railcraft/api/carts/CartToolsAPI.java
+++ b/mods/railcraft/api/carts/CartToolsAPI.java
@@ -121,7 +121,7 @@ public abstract class CartToolsAPI {
             return mi.placeCart(owner, cart, world, pos);
         } else if (cart.getItem() instanceof ItemMinecart)
             try {
-                EnumActionResult placed = cart.getItem().onItemUse(cart, RailcraftFakePlayer.get(world, pos), world, pos, EnumHand.MAIN_HAND, EnumFacing.DOWN, 0, 0, 0);
+                EnumActionResult placed = cart.getItem().onItemUse(RailcraftFakePlayer.get(world, pos, cart), world, pos, EnumHand.MAIN_HAND, EnumFacing.DOWN, 0, 0, 0);
                 if (placed == EnumActionResult.SUCCESS) {
                     List<EntityMinecart> carts = getMinecartsAt(world, pos, 0.3f);
                     if (carts.size() > 0) {

--- a/mods/railcraft/api/core/RailcraftFakePlayer.java
+++ b/mods/railcraft/api/core/RailcraftFakePlayer.java
@@ -9,6 +9,9 @@ package mods.railcraft.api.core;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.FakePlayerFactory;
@@ -26,17 +29,31 @@ public class RailcraftFakePlayer {
 
     public static final GameProfile RAILCRAFT_USER_PROFILE = new GameProfile(UUID.nameUUIDFromBytes(RailcraftConstantsAPI.RAILCRAFT_PLAYER.getBytes()), RailcraftConstantsAPI.RAILCRAFT_PLAYER);
 
-    public static EntityPlayer get(final WorldServer world, final double x, final double y, final double z) {
-        EntityPlayer player = FakePlayerFactory.get(world, RAILCRAFT_USER_PROFILE);
+    public static EntityPlayerMP get(final WorldServer world, final double x, final double y, final double z) {
+        EntityPlayerMP player = FakePlayerFactory.get(world, RAILCRAFT_USER_PROFILE);
         assert player != null;
         player.setPosition(x, y, z);
         return player;
     }
 
-    public static EntityPlayer get(final WorldServer world, final BlockPos pos) {
-        EntityPlayer player = FakePlayerFactory.get(world, RAILCRAFT_USER_PROFILE);
+    public static EntityPlayerMP get(final WorldServer world, final double x, final double y, final double z, final ItemStack stack) {
+        EntityPlayerMP player = get(world, x, y, z);
+        player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, stack);
+        player.setItemStackToSlot(EntityEquipmentSlot.OFFHAND, stack);
+        return player;
+    }
+
+    public static EntityPlayerMP get(final WorldServer world, final BlockPos pos) {
+        EntityPlayerMP player = FakePlayerFactory.get(world, RAILCRAFT_USER_PROFILE);
         assert player != null;
         player.setPosition(pos.getX(), pos.getY(), pos.getZ());
+        return player;
+    }
+
+    public static EntityPlayerMP get(final WorldServer world, final BlockPos pos, final ItemStack stack) {
+        EntityPlayerMP player = get(world, pos);
+        player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, stack);
+        player.setItemStackToSlot(EntityEquipmentSlot.OFFHAND, stack);
         return player;
     }
 }

--- a/mods/railcraft/api/core/RailcraftItemStackRegistry.java
+++ b/mods/railcraft/api/core/RailcraftItemStackRegistry.java
@@ -64,7 +64,7 @@ public class RailcraftItemStackRegistry {
         ItemStack stack = stacks.get(tag);
         if (stack != null) {
             stack = stack.copy();
-            stack.stackSize = Math.min(qty, stack.getMaxStackSize());
+            stack.setCount(Math.min(qty, stack.getMaxStackSize()));
         }
         return Optional.ofNullable(stack);
     }

--- a/mods/railcraft/api/core/items/ITrackItem.java
+++ b/mods/railcraft/api/core/items/ITrackItem.java
@@ -40,7 +40,7 @@ public interface ITrackItem {
      * @return true if successful
      */
     default boolean placeTrack(ItemStack stack, @Nullable EntityPlayer player, World world, BlockPos pos, @Nullable BlockRailBase.EnumRailDirection trackShape) {
-        return stack.getItem().onItemUse(stack, player, world, pos.down(), EnumHand.MAIN_HAND, EnumFacing.UP, 0, 0, 0) == EnumActionResult.SUCCESS;
+        return stack.getItem().onItemUse(player, world, pos.down(), EnumHand.MAIN_HAND, EnumFacing.UP, 0, 0, 0) == EnumActionResult.SUCCESS;
     }
 
     /**

--- a/mods/railcraft/api/signals/SignalBlock.java
+++ b/mods/railcraft/api/signals/SignalBlock.java
@@ -271,8 +271,8 @@ public abstract class SignalBlock extends AbstractPair {
 //        System.out.println("carts = " + carts.size());
         SignalAspect newAspect = SignalAspect.GREEN;
         for (EntityMinecart cart : carts) {
-            int cartX = MathHelper.floor_double(cart.posX);
-            int cartZ = MathHelper.floor_double(cart.posZ);
+            int cartX = MathHelper.floor(cart.posX);
+            int cartZ = MathHelper.floor(cart.posZ);
             if (Math.abs(cart.motionX) < 0.08 && Math.abs(cart.motionZ) < 0.08)
                 return SignalAspect.RED;
             else if (zAxis)

--- a/mods/railcraft/api/tracks/TrackKit.java
+++ b/mods/railcraft/api/tracks/TrackKit.java
@@ -174,7 +174,7 @@ public final class TrackKit implements IVariantEnum, ILocalizedObject {
     public ItemStack getTrackKitItem(int qty) {
         if (itemKit != null) {
             ItemStack stack = new ItemStack(itemKit, qty, ordinal());
-            NBTTagCompound nbt = stack.getSubCompound(RailcraftConstantsAPI.MOD_ID, true);
+            NBTTagCompound nbt = stack.getOrCreateSubCompound(RailcraftConstantsAPI.MOD_ID);
             nbt.setString(NBT_TAG, getName());
             return stack;
         }
@@ -200,7 +200,7 @@ public final class TrackKit implements IVariantEnum, ILocalizedObject {
     public ItemStack getOutfittedTrack(TrackType trackType, int qty) {
         if (blockTrackOutfitted != null) {
             ItemStack stack = new ItemStack(blockTrackOutfitted, qty);
-            NBTTagCompound nbt = stack.getSubCompound(RailcraftConstantsAPI.MOD_ID, true);
+            NBTTagCompound nbt = stack.getOrCreateSubCompound(RailcraftConstantsAPI.MOD_ID);
             nbt.setString(TrackType.NBT_TAG, trackType.getName());
             nbt.setString(NBT_TAG, getName());
             return stack;

--- a/mods/railcraft/api/tracks/TrackKitInstance.java
+++ b/mods/railcraft/api/tracks/TrackKitInstance.java
@@ -97,7 +97,7 @@ public abstract class TrackKitInstance implements ITrackKitInstance {
     @Override
     public void onBlockPlacedBy(IBlockState state, @Nullable EntityLivingBase placer, ItemStack stack) {
         if (placer != null && this instanceof ITrackKitReversible) {
-            int dir = MathHelper.floor_double((double) ((placer.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+            int dir = MathHelper.floor((double) ((placer.rotationYaw * 4F) / 360F) + 0.5D) & 3;
             ((ITrackKitReversible) this).setReversed(dir == 0 || dir == 1);
         }
         switchTrack(state, true);
@@ -138,11 +138,11 @@ public abstract class TrackKitInstance implements ITrackKitInstance {
         if (powered != r.isPowered()) {
             r.setPowered(powered);
             Block blockTrack = getBlock();
-            world.notifyNeighborsOfStateChange(getPos(), blockTrack);
-            world.notifyNeighborsOfStateChange(getPos().down(), blockTrack);
+            world.notifyNeighborsOfStateChange(getPos(), blockTrack, true);
+            world.notifyNeighborsOfStateChange(getPos().down(), blockTrack, true);
             BlockRailBase.EnumRailDirection railDirection = state.getValue(((BlockRailBase) state.getBlock()).getShapeProperty());
             if (railDirection.isAscending())
-                world.notifyNeighborsOfStateChange(getPos().up(), blockTrack);
+                world.notifyNeighborsOfStateChange(getPos().up(), blockTrack, true);
             sendUpdateToClient();
             // System.out.println("Setting power [" + i + ", " + j + ", " + k + "]");
         }

--- a/mods/railcraft/api/tracks/TrackRegistry.java
+++ b/mods/railcraft/api/tracks/TrackRegistry.java
@@ -142,7 +142,7 @@ public class TrackRegistry<T extends IStringSerializable> {
     }
 
     public T get(ItemStack stack) {
-        NBTTagCompound nbt = stack.getSubCompound(RailcraftConstantsAPI.MOD_ID, false);
+        NBTTagCompound nbt = stack.getSubCompound(RailcraftConstantsAPI.MOD_ID);
         if (nbt != null)
             return get(nbt);
         return getFallback();


### PR DESCRIPTION
This pull is more a notification of 1.11 than a real update. This removed some IC2, BuildCraft, Forestry and Thaumcraft compact code, since they had not updated to Minecraft 1.11 yet.