### PR TITLE
Fix outfitted track speed ignoring track type

### DIFF
--- a/mods/railcraft/api/tracks/ITrackKitInstance.java
+++ b/mods/railcraft/api/tracks/ITrackKitInstance.java
@@ -125,8 +125,8 @@ public interface ITrackKitInstance extends INetworkedObject<DataInputStream, Dat
      * @param cart The cart on the rail, may be null.
      * @return The max speed of the current rail.
      */
-    default float getRailMaxSpeed(World world, EntityMinecart cart, BlockPos pos) {
-        return 0.4F;
+    default float getRailMaxSpeed(World world, @Nullable EntityMinecart cart, BlockPos pos, TrackType type) {
+        return type.getEventHandler().getMaxSpeed(world, cart, pos);
     }
 
     /**
@@ -134,6 +134,13 @@ public interface ITrackKitInstance extends INetworkedObject<DataInputStream, Dat
      */
     default boolean isProtected() {
         return false;
+    }
+
+    /**
+     * Returns the track type of this track.
+     */
+    default TrackType getTrackType() {
+        return TrackToolsAPI.getTypeForTrackKitInstance(this);
     }
 
 }

--- a/mods/railcraft/api/tracks/ITrackKitInstance.java
+++ b/mods/railcraft/api/tracks/ITrackKitInstance.java
@@ -125,8 +125,8 @@ public interface ITrackKitInstance extends INetworkedObject<DataInputStream, Dat
      * @param cart The cart on the rail, may be null.
      * @return The max speed of the current rail.
      */
-    default float getRailMaxSpeed(World world, @Nullable EntityMinecart cart, BlockPos pos, TrackType type) {
-        return type.getEventHandler().getMaxSpeed(world, cart, pos);
+    default float getRailMaxSpeed(World world, @Nullable EntityMinecart cart, BlockPos pos) {
+        return getTrackType().getEventHandler().getMaxSpeed(world, cart, pos);
     }
 
     /**
@@ -140,7 +140,7 @@ public interface ITrackKitInstance extends INetworkedObject<DataInputStream, Dat
      * Returns the track type of this track.
      */
     default TrackType getTrackType() {
-        return TrackToolsAPI.getTypeForTrackKitInstance(this);
+        return ((IOutfittedTrackTile) getTile()).getTrackType();
     }
 
 }

--- a/mods/railcraft/api/tracks/TrackToolsAPI.java
+++ b/mods/railcraft/api/tracks/TrackToolsAPI.java
@@ -7,6 +7,8 @@
 
 package mods.railcraft.api.tracks;
 
+import mods.railcraft.api.core.RailcraftConstantsAPI;
+import mods.railcraft.api.core.RailcraftCore;
 import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.api.core.items.ITrackItem;
 import net.minecraft.block.Block;
@@ -23,6 +25,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.common.Loader;
+
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -32,7 +37,7 @@ import javax.annotation.Nullable;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 @SuppressWarnings({"WeakerAccess"})
-public abstract class TrackToolsAPI {
+public final class TrackToolsAPI {
     /**
      * Check if the block at the location is a Track.
      */
@@ -200,5 +205,22 @@ public abstract class TrackToolsAPI {
 //        }
 //        return null;
 //    }
+
+    public static TrackType getTypeForTrackKitInstance(ITrackKitInstance instance) {
+        TileEntity tile = instance.getTile();
+        return trackTypeFunction == null ? TrackRegistry.TRACK_TYPE.getFallback() : trackTypeFunction.apply(tile);
+    }
+
+    private static Function<TileEntity, TrackType> trackTypeFunction;
+
+    /**
+     * Other mods don't use this!
+     */
+    @Deprecated
+    public static void setTrackTypeFunction(Function<TileEntity, TrackType> function) {
+        trackTypeFunction = function;
+    }
+
+    private TrackToolsAPI() {}
 
 }

--- a/mods/railcraft/api/tracks/TrackToolsAPI.java
+++ b/mods/railcraft/api/tracks/TrackToolsAPI.java
@@ -7,8 +7,6 @@
 
 package mods.railcraft.api.tracks;
 
-import mods.railcraft.api.core.RailcraftConstantsAPI;
-import mods.railcraft.api.core.RailcraftCore;
 import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.api.core.items.ITrackItem;
 import net.minecraft.block.Block;
@@ -25,9 +23,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
-import net.minecraftforge.fml.common.Loader;
-
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 

--- a/mods/railcraft/api/tracks/TrackToolsAPI.java
+++ b/mods/railcraft/api/tracks/TrackToolsAPI.java
@@ -206,21 +206,6 @@ public final class TrackToolsAPI {
 //        return null;
 //    }
 
-    public static TrackType getTypeForTrackKitInstance(ITrackKitInstance instance) {
-        TileEntity tile = instance.getTile();
-        return trackTypeFunction == null ? TrackRegistry.TRACK_TYPE.getFallback() : trackTypeFunction.apply(tile);
-    }
-
-    private static Function<TileEntity, TrackType> trackTypeFunction;
-
-    /**
-     * Other mods don't use this!
-     */
-    @Deprecated
-    public static void setTrackTypeFunction(Function<TileEntity, TrackType> function) {
-        trackTypeFunction = function;
-    }
-
     private TrackToolsAPI() {}
 
 }

--- a/mods/railcraft/api/tracks/TrackType.java
+++ b/mods/railcraft/api/tracks/TrackType.java
@@ -174,7 +174,7 @@ public class TrackType implements IStringSerializable, ILocalizedObject {
         public void onEntityCollidedWithBlock(World world, BlockPos pos, IBlockState state, Entity entity) {
         }
 
-        public float getMaxSpeed(World world, EntityMinecart cart, BlockPos pos) {
+        public float getMaxSpeed(World world, @Nullable EntityMinecart cart, BlockPos pos) {
             return 0.4f;
         }
     }


### PR DESCRIPTION
This allows track kits to determine the track type in order to handle the speed correctly. Added some reasonable annotations, too.