### PR TITLE
Write a clean game profile to owner tag

### DIFF
--- a/src/main/java/mods/railcraft/api/carts/CartToolsAPI.java
+++ b/src/main/java/mods/railcraft/api/carts/CartToolsAPI.java
@@ -72,7 +72,7 @@ public final class CartToolsAPI {
     public static void setCartOwner(EntityMinecart cart, GameProfile owner) {
         if (!cart.getEntityWorld().isRemote) {
             NBTTagCompound data = cart.getEntityData();
-            data.setTag("owner", NBTUtil.writeGameProfile(new NBTTagCompound(), owner));
+            data.setTag("owner", NBTUtil.writeGameProfile(new NBTTagCompound(), new GameProfile(owner.getId(), owner.getName())));
 //            if (owner.getName() != null)
 //                data.setString("owner", owner.getName());
 //            if (owner.getId() != null)


### PR DESCRIPTION
Directly pasting an existing game profile may cause the whole skin texture information be pasted onto minecart tags. This is very wasteful and disrupts debugging with `/entitydata` commands to check individual cart data because of the texture base64 spam.