### PR TITLE
Deprecate this method for cubic chunks compatibility

### DIFF
--- a/src/main/java/mods/railcraft/api/core/WorldCoordinate.java
+++ b/src/main/java/mods/railcraft/api/core/WorldCoordinate.java
@@ -147,6 +147,7 @@ public final class WorldCoordinate {
         return new Vec3d(getPos());
     }
 
+    @Deprecated // cubic chunks
     public boolean isBelowWorld() {
         return getY() < 0;
     }


### PR DESCRIPTION
Signed-off-by: liach <liach@users.noreply.github.com>

This method is used nowhere in railcraft itself, so I simply deprecated it.